### PR TITLE
Upgraded Itinero and fixed OsmTransferGenerator.

### DIFF
--- a/src/Itinero.Transit.IO.OSM/Itinero.Transit.IO.OSM.csproj
+++ b/src/Itinero.Transit.IO.OSM/Itinero.Transit.IO.OSM.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="GeoTimeZone" Version="3.2.0" />
         <PackageReference Include="NodaTime" Version="2.4.5" />
-        <PackageReference Include="openplannerteam.Itinero.IO.Osm.Tiles" Version="2.0.0-pre012" />
+        <PackageReference Include="openplannerteam.Itinero.IO.Osm.Tiles" Version="2.0.0-pre016" />
         <PackageReference Include="OsmSharp" Version="6.2.0" />
     </ItemGroup>
 

--- a/src/Itinero.Transit.IO.OSM/OsmTransferGenerator.cs
+++ b/src/Itinero.Transit.IO.OSM/OsmTransferGenerator.cs
@@ -26,9 +26,9 @@ namespace Itinero.Transit.IO.OSM
 
         private readonly float _searchDistance;
 
-        public static void EnableCaching(string cachindDirectory)
+        public static void EnableCaching(string cachingDirectory)
         {
-            TileParser.DownloadFunc = new TilesDownloadHelper(cachindDirectory).Download;
+            TileParser.DownloadFunc = new TilesDownloadHelper(cachingDirectory).Download;
         }
 
         ///  <summary>
@@ -37,16 +37,15 @@ namespace Itinero.Transit.IO.OSM
         /// 
         ///  Footpaths are generated using an Osm-based router database
         ///  </summary>
+        ///  <param name="routerDb">The router db to use.</param>
         ///  <param name="searchDistance">The maximum distance that the traveller takes this route</param>
         ///  <param name="profile">The vehicle profile, default is pedestrian.</param>
-        ///  <param name="baseTilesUrl">The base tile url.</param>
-        public OsmTransferGenerator(float searchDistance = 1000,
+        public OsmTransferGenerator(RouterDb routerDb, float searchDistance = 1000,
             Profile profile = null)
         {
+            _routerDb = routerDb ?? throw new ArgumentNullException(nameof(routerDb));
             _searchDistance = searchDistance;
             _profile = profile ?? OsmProfiles.Pedestrian;
-            _routerDb = new RouterDb();
-            _routerDb.DataProvider = new DataProvider(_routerDb);
         }
 
         public uint TimeBetween(IStop from, IStop to)

--- a/src/Itinero.Transit.IO.OSM/TilesDownloadHelper.cs
+++ b/src/Itinero.Transit.IO.OSM/TilesDownloadHelper.cs
@@ -11,6 +11,7 @@ namespace Itinero.Transit.IO.OSM
     /// Copies the http-response to file.
     /// Adds a checksum to detect corruptions
     /// </summary>
+    // TODO: remove this later, the cache should be the router db only.
     internal class TilesDownloadHelper
     {
         private readonly string _cachingDir;

--- a/test/Itinero.Transit.Tests.Functional/FullStack/FullStackTest.cs
+++ b/test/Itinero.Transit.Tests.Functional/FullStack/FullStackTest.cs
@@ -7,6 +7,7 @@ using Itinero.Transit.Journey.Filter;
 using Itinero.Transit.Journey.Metric;
 using Itinero.Transit.OtherMode;
 using Itinero.Transit.Tests.Functional.Algorithms;
+using Itinero.Transit.Tests.Functional.Staging;
 
 namespace Itinero.Transit.Tests.Functional.FullStack
 {
@@ -22,7 +23,7 @@ namespace Itinero.Transit.Tests.Functional.FullStack
 
             var defaultRealLifeProfile = new Profile<TransferMetric>(
                 new InternalTransferGenerator(180),
-                new OsmTransferGenerator().UseCache(),
+                new OsmTransferGenerator(RouterDbStaging.RouterDb).UseCache(),
                 TransferMetric.Factory,
                 TransferMetric.ParetoCompare,
                 new CancelledConnectionFilter(),

--- a/test/Itinero.Transit.Tests.Functional/IO/OSM/Itinero2RoutingTest.cs
+++ b/test/Itinero.Transit.Tests.Functional/IO/OSM/Itinero2RoutingTest.cs
@@ -5,6 +5,7 @@ using Itinero.Transit.IO.OSM.Data;
 using Itinero.Transit.Journey.Metric;
 using Itinero.Transit.OtherMode;
 using Itinero.Transit.Tests.Functional.Algorithms;
+using Itinero.Transit.Tests.Functional.Staging;
 
 namespace Itinero.Transit.Tests.Functional.IO.OSM
 {
@@ -22,9 +23,7 @@ namespace Itinero.Transit.Tests.Functional.IO.OSM
             var from = Constants.NearStationBruggeLatLonRijselse;
             var to = Constants.Brugge;
 
-
-            OsmTransferGenerator.EnableCaching("./cache");
-            var gen = new OsmTransferGenerator(5000,
+            var gen = new OsmTransferGenerator(RouterDbStaging.RouterDb, 5000,
                 OsmProfiles.Pedestrian
             );
 

--- a/test/Itinero.Transit.Tests.Functional/Itinero.Transit.Tests.Functional.csproj
+++ b/test/Itinero.Transit.Tests.Functional/Itinero.Transit.Tests.Functional.csproj
@@ -22,9 +22,4 @@
       <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     </ItemGroup>
 
-
-    <ItemGroup>
-      <Folder Include="Staging" />
-    </ItemGroup>
-
 </Project>

--- a/test/Itinero.Transit.Tests.Functional/Program.cs
+++ b/test/Itinero.Transit.Tests.Functional/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Itinero.Data.Graphs.Coders;
+using Itinero.IO.Osm.Tiles;
 using Itinero.IO.Osm.Tiles.Parsers;
 using Itinero.Transit.Data;
 using Itinero.Transit.IO.OSM;
@@ -13,6 +15,7 @@ using Itinero.Transit.Tests.Functional.IO;
 using Itinero.Transit.Tests.Functional.IO.LC;
 using Itinero.Transit.Tests.Functional.IO.LC.Synchronization;
 using Itinero.Transit.Tests.Functional.IO.OSM;
+using Itinero.Transit.Tests.Functional.Staging;
 using Serilog;
 using Serilog.Events;
 using Serilog.Formatting.Json;
@@ -34,10 +37,14 @@ namespace Itinero.Transit.Tests.Functional
 
             var devTestsOnly = args.Length == 0 ||
                                !new List<string> {"--full-test-suite", "--full", "--test"}.Contains(args[0].ToLower());
+            
+            // use one router db globally.
+            RouterDbStaging.Setup();
 
             // do some local caching.
             if (devTestsOnly)
             {
+                new Itinero2RoutingTest().Run();
                 return;
             }
 

--- a/test/Itinero.Transit.Tests.Functional/Staging/RouterDbStaging.cs
+++ b/test/Itinero.Transit.Tests.Functional/Staging/RouterDbStaging.cs
@@ -1,0 +1,27 @@
+using Itinero.Data.Graphs.Coders;
+using Itinero.IO.Osm.Tiles;
+using Itinero.Transit.IO.OSM;
+
+namespace Itinero.Transit.Tests.Functional.Staging
+{
+    public static class RouterDbStaging
+    {
+        public static RouterDb RouterDb { get; private set; }
+
+        public static void Setup()
+        {
+            var routerDb = new RouterDb(new RouterDbConfiguration()
+            {
+                Zoom = 14,
+                EdgeDataLayout = new EdgeDataLayout(new (string key, EdgeDataType dataType)[]
+                {
+                    ("bicycle.weight", EdgeDataType.UInt32) // add one for each profile that is going to be used with name (profile).weight.
+                })
+            });
+            routerDb.DataProvider = new DataProvider(routerDb);
+            OsmTransferGenerator.EnableCaching("cache");
+
+            RouterDbStaging.RouterDb = routerDb;
+        }
+    }
+}

--- a/test/Itinero.Transit.Tests/IO/OSM/TestBareRouting.cs
+++ b/test/Itinero.Transit.Tests/IO/OSM/TestBareRouting.cs
@@ -49,8 +49,8 @@ namespace Itinero.Transit.Tests.IO.OSM
 
             var pedestrian = OsmProfiles.Pedestrian;
 
-
-            var p = new OsmTransferGenerator(profile: pedestrian);
+            // TODO: this should not be in the unit tests, it uses the web to load data.
+            var p = new OsmTransferGenerator(new RouterDb(), profile: pedestrian);
             // Rijselstraat, just behind the station
       
             var route = p.CreateRoute(( 51.193350000000009f, 3.2137800000000141f), (51.197229555160746f, 3.2167249917984009f), out _);


### PR DESCRIPTION
I have:

- Updated Itinero2 and added a basic way to setup one routerdb to reuse. Currently for each OsmTransferGenerator a new routerdb was created and loads to reload the graph on every request.
- For now the routerdb has to configured to store the weights for all the profiles used *before* it is created. This can be done like this: https://github.com/openplannerteam/itinero-tiled-routing/blob/master/test/Itinero.Tests.Functional/Program.cs#L43 Later this will be dynamically configurable.

@pietervdvn please review and ping me if you need more info. 

I found it hard to test if everything worked as some functional tests failed. I think we need to expand the intermodal functional tests to better test itinero integration.